### PR TITLE
[TASK] Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+/Build/**
+!/Build/Surf**
+/Configuration/**
+!/Configuration/**.yaml
+/Data/
+/Web/
+/bin/
+/Readme.txt
+/Upgrading.txt
+/flow
+/flow.bat
+/Readme.rst
+/Upgrading.rst
+/Packages/**


### PR DESCRIPTION
This adds a .gitignore file to the distribution. Acutally it’s
the same file we are using for the neos development
distribution.