### PR TITLE
TASK: Pin phpunit/phpunit-mock-objects to 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "typo3/kickstart": "2.3.x-dev",
         "typo3/buildessentials": "2.3.x-dev",
         "phpunit/phpunit": "~4.8 | ~5.2.0",
+        "phpunit/phpunit-mock-objects": "~3.1.0",
         "mikey179/vfsstream": "~1.6",
         "flowpack/behat": "dev-master"
     },


### PR DESCRIPTION
This "fixes" the test failures caused by changes in the mock objects library.