### PR TITLE
TASK: Ignore errors when fetching PR details

### DIFF
--- a/Build/create-changelog.sh
+++ b/Build/create-changelog.sh
@@ -43,7 +43,7 @@ for mergeCommit in $(git log $PREVIOUS_VERSION.. --grep="^Merge pull request" --
 		echo "fetching info from https://api.github.com/repos/neos/flow-development-collection/pulls/$pullRequest?access_token=<...>"
 		curl -sS "https://api.github.com/repos/neos/flow-development-collection/pulls/$pullRequest?access_token=$GITHUB_TOKEN" > pr
 	fi
-	if [[ $(cat pr | jq '.message') != "null" ]]; then cat pr | jq -r '.message'; exit 1; fi
+	if [[ $(cat pr | jq '.message') != "null" ]]; then cat pr | jq -r '.message'; continue; fi
 	echo "\`"$(cat pr | jq -r '.title' | sed 's/`/\\`/g')" <"https://github.com/neos/flow-development-collection/pull/$pullRequest">\`_" >> $TARGET
 	perl -E 'say "-" x '$(echo $(($(tail -1 $TARGET | wc -c) - 1))) >> ${TARGET}
 	echo >> $TARGET


### PR DESCRIPTION
When building a changelog, the script would exit if PR details could
not be fetched. Since this can happen due to "malformed" commit messages
the script will now simply continue with the next change.

This makes sure a changelog is generated and not skipped completely,
just because PR details cannot be fetched.