### PR TITLE
!!! FEATURE: Raise phpunit to v8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "neos/flow-development-collection": "dev-master",
         "neos/welcome": "dev-master",
-        "phpunit/phpunit": "~7.1",
+        "phpunit/phpunit": "~8.1",
         "mikey179/vfsstream": "~1.6",
         "neos/behat": "dev-master",
         "neos/fluid-adaptor": "dev-master"


### PR DESCRIPTION
This change raises the phpunit requirement to v8.1. This might be breaking for you as phpunit introduced return types on methods like `public setUp(): void` as well as `public tearDown(): void`. PHPUnit also deprecated a lot of methods. You might find [here](https://thephp.cc/news/2019/02/help-my-tests-stopped-working) some more background information about replacements for your assertions.

Resolves https://github.com/neos/flow-development-collection/issues/1506
