### PR TITLE
TASK: Remove neos/fluid-adaptor require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "suggest": {
         "ext-pdo_sqlite": "For running functional tests out-of-the-box this is required",
-        "neos/fluid-adaptor": "For rendering HTML templates"
+        "neos/fluid-adaptor": "For rendering templates with TYPO3.Fluid"
     },
     "scripts": {
         "post-update-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
         }
     },
     "suggest": {
-        "ext-pdo_sqlite": "For running functional tests out-of-the-box this is required",
-        "neos/fluid-adaptor": "For rendering templates with TYPO3.Fluid"
+        "ext-pdo_sqlite": "For running functional tests out-of-the-box this is required"
     },
     "scripts": {
         "post-update-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,21 @@
         "phpunit/phpunit": "~9.0",
         "mikey179/vfsstream": "~1.6",
         "vimeo/psalm": "~4.1.1",
-        "neos/behat": "dev-master"
+        "neos/behat": "dev-master",
+        "neos/flow": "7.0.x-dev",
+        "neos/cache": "7.0.x-dev",
+        "neos/eel": "7.0.x-dev",
+        "neos/error-messages": "7.0.x-dev",
+        "neos/flow-log": "7.0.x-dev",
+        "neos/utility-arrays": "7.0.x-dev",
+        "neos/utility-files": "7.0.x-dev",
+        "neos/utility-mediatypes": "7.0.x-dev",
+        "neos/utility-objecthandling": "7.0.x-dev",
+        "neos/utility-opcodecache": "7.0.x-dev",
+        "neos/utility-pdo": "7.0.x-dev",
+        "neos/utility-schema": "7.0.x-dev",
+        "neos/utility-unicode": "7.0.x-dev",
+        "neos/http-factories": "7.0.x-dev"
     },
     "repositories": {
         "distributionPackages": {

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
         "neos/welcome": "dev-master",
         "phpunit/phpunit": "~8.1",
         "mikey179/vfsstream": "~1.6",
-        "neos/behat": "dev-master",
-        "neos/fluid-adaptor": "dev-master"
+        "neos/behat": "dev-master"
     },
     "repositories": {
         "distributionPackages": {
@@ -30,7 +29,8 @@
         }
     },
     "suggest": {
-        "ext-pdo_sqlite": "For running functional tests out-of-the-box this is required"
+        "ext-pdo_sqlite": "For running functional tests out-of-the-box this is required",
+        "neos/fluid-adaptor": "For rendering HTML templates"
     },
     "scripts": {
         "post-update-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",


### PR DESCRIPTION
As of neos/flow-development-collection#2151 the neos/fluid-adaptor is moved to a suggested package