### PR TITLE
TASK: Require neos/fluid-adaptor in update-references.sh

### DIFF
--- a/Build/update-references.sh
+++ b/Build/update-references.sh
@@ -13,6 +13,7 @@ git reset --hard origin/${BRANCH}
 # install dependencies
 php $(dirname ${BASH_SOURCE[0]})/../composer.phar update --no-interaction --no-progress --no-suggest
 php $(dirname ${BASH_SOURCE[0]})/../composer.phar require --no-interaction --no-progress neos/doctools
+php $(dirname ${BASH_SOURCE[0]})/../composer.phar require --no-interaction --no-progress neos/fluid-adaptor
 
 # render references
 ./flow cache:warmup


### PR DESCRIPTION
While it is only optional with neos/flow-development-collection#2152 we still need it for this.