### PR TITLE
TASK: Skip Travis CI on references update

### DIFF
--- a/Build/update-references.sh
+++ b/Build/update-references.sh
@@ -29,7 +29,7 @@ done
 # commit and push results to Framework dev collection
 echo 'Commit and push to Framework'
 git add Neos.Flow/Documentation/TheDefinitiveGuide/PartV
-git commit -m 'TASK: Update references'
+git commit -m 'TASK: Update references [skip travis]'
 git config push.default simple
 git push origin ${BRANCH}
 cd -


### PR DESCRIPTION
Since docs updates don't need to be tested, this is a no-risk way
of hopefully reducing build time use on Travis.

See https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build