### PR TITLE
BUGFIX: Activate Flow routes by default

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,0 +1,8 @@
+Neos:
+  Flow:
+    mvc:
+      routes:
+        # The following lines register the Flow default routes
+        # For productive use you should move this setting to the main package of this
+        # application and/or create custom routes.
+        'Neos.Flow': true


### PR DESCRIPTION
Adjusts `Configuration/Settings.yaml` so that the
Flow routes are active by default.

Otherwise, following the "Getting started" from `neos/welcome` will
lead to an exception since the link in

> Click on this link to see your new package in action

can't be resolved.