### PR TITLE
TASK: Remove fluid-adaptor dependency from release distribution

### DIFF
--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -78,6 +78,7 @@ else
     php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/eel"
     php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/error-messages"
     php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/flow-log"
+    php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/fluid-adaptor"
     php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-arrays"
     php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-files"
     php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-mediatypes"


### PR DESCRIPTION
Otherwise a pre-existing `${BRANCH}.x-dev` dependency will prevail, see https://github.com/neos/flow-base-distribution/blob/7.0.0/composer.json#L21. It should actually end up as "suggest".