### PR TITLE
TASK: Tag releases for BuildEssentials, Behat and Welcome on initial releases

### DIFF
--- a/Build/tag-release.sh
+++ b/Build/tag-release.sh
@@ -45,3 +45,18 @@ echo "Tagging development collection"
 tag_version ${VERSION} ${BRANCH} "${BUILD_URL}" "Packages/Framework"
 push_branch ${BRANCH} "Packages/Framework"
 push_tag ${VERSION} "Packages/Framework"
+
+if [[ "$VERSION" == *.0 ]]
+then
+  echo "Tagging buildessentials"
+  tag_version ${VERSION} ${BRANCH} "${BUILD_URL}" "Build/BuildEssentials"
+  push_tag ${VERSION} "Build/BuildEssentials"
+
+  echo "Tagging behat"
+  tag_version ${VERSION} ${BRANCH} "${BUILD_URL}" "Packages/Application/Neos.Behat"
+  push_tag ${VERSION} "Packages/Application/Neos.Behat"
+
+  echo "Tagging welcome"
+  tag_version ${VERSION} ${BRANCH} "${BUILD_URL}" "Packages/Application/Neos.Welcome"
+  push_tag ${VERSION} "Packages/Application/Neos.Welcome"
+fi


### PR DESCRIPTION
We already create branches in sync with Flow for those packages - see https://github.com/neos/flow-development-distribution/blob/master/Build/create-branch.sh#L54-L57 - and update the dependencies - see https://github.com/neos/flow-development-distribution/blob/master/Build/set-dependencies.sh#L119-L120
However, on release, versions for those branches are not tagged and hence need to be added manually, which can easily be forgotten - see https://github.com/neos/neos-base-distribution/pull/52#issuecomment-830197685