### PR TITLE
TASK: Fix minimum PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "neos/flow-development-collection": "6.3.x-dev",
         "neos/welcome": "6.3.x-dev",
-        "phpunit/phpunit": "~8.1",
+        "phpunit/phpunit": "~8.5",
         "mikey179/vfsstream": "^1.6.1",
         "vimeo/psalm": "~4.1.1",
         "neos/behat": "6.1.x-dev",


### PR DESCRIPTION
See https://github.com/neos/flow-development-collection/pull/2454 - our tests don't run with PHPUnit < 8.5 any more