### PR TITLE
TASK: Prefer installing of neos packages from source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,10 @@
     },
     "config": {
         "vendor-dir": "Packages/Libraries",
-        "bin-dir": "bin"
+        "bin-dir": "bin",
+        "preferred-install": {
+            "neos/*": "source"
+        }
     },
     "require": {
         "neos/flow-development-collection": "dev-master",


### PR DESCRIPTION
Since this is the development distribution for flow composer should install all neos packages from source.

See https://getcomposer.org/doc/06-config.md#preferred-install

resolves: #71 