### PR TITLE
TASK: Fix requirements of dev packages

### DIFF
--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -57,8 +57,13 @@ echo "Setting distribution dependencies"
 
 # Require exact versions of the main packages
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/flow:${VERSION}"
+
 # Require some version of the same minor level of the main packages
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/welcome:~${BRANCH}.0"
+if [[ ${STABILITY_FLAG} ]]; then
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/welcome:${BRANCH}.x-dev"
+else
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/welcome:~${BRANCH}.0"
+fi
 
 # Require exact versions of sub dependency packages, allowing unstable
 if [[ ${STABILITY_FLAG} ]]; then
@@ -97,10 +102,15 @@ fi
 
 # Require exact versions of the main dev packages
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/kickstarter:${VERSION}"
-# Require some version of the same minor level of main dev packages
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:~${BRANCH}.0"
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:~${BRANCH}.0"
 
+# Require some version of the same minor level of main dev packages
+if [[ ${STABILITY_FLAG} ]]; then
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:${BRANCH}.x-dev"
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${BRANCH}.x-dev"
+else
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:~${BRANCH}.0"
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:~${BRANCH}.0"
+fi
 commit_manifest_update "${BRANCH}" "${BUILD_URL}" "${VERSION}" "Distribution"
 
 echo "Setting packages dependencies"

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -57,8 +57,8 @@ echo "Setting distribution dependencies"
 
 # Require exact versions of the main packages
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/flow:${VERSION}"
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/welcome:${VERSION}"
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:${VERSION}"
+# Require some version of the same minor level
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/welcome:~${BRANCH}.0"
 
 # Require exact versions of sub dependency packages, allowing unstable
 if [[ ${STABILITY_FLAG} ]]; then
@@ -95,8 +95,11 @@ else
   php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/fluid-adaptor"
 fi
 
+# Require exact versions of the main dev packages
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/kickstarter:${VERSION}"
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${VERSION}"
+# Require some version of the same minor level of main dev packages
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:~${BRANCH}.0"
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:~${BRANCH}.0"
 
 commit_manifest_update "${BRANCH}" "${BUILD_URL}" "${VERSION}" "Distribution"
 

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -57,7 +57,7 @@ echo "Setting distribution dependencies"
 
 # Require exact versions of the main packages
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/flow:${VERSION}"
-# Require some version of the same minor level
+# Require some version of the same minor level of the main packages
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/welcome:~${BRANCH}.0"
 
 # Require exact versions of sub dependency packages, allowing unstable


### PR DESCRIPTION
The following packages have only a automatic deployment on the first release of each minor version (x.y.0):
* neos/welcome
* neos/behat
* neos/buildessentials

After the first release in the minor version, we need to do tag new versions manually and the version numbers are not in sync with the flow release versions. 

To ensure, a matching version of the packages listed above, we need to set the constraints to `~x.y.0`, which allows to install at least the automatically released version, but also newer versions that are tagged manually.

See also: https://neos-project.slack.com/archives/C04PYL8H3/p1720790338419519