### PR TITLE
TASK: simplify beta releases by using composer minimum stability

### DIFF
--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -24,11 +24,11 @@ if [ -z "$1" ]; then
   exit 1
 else
   if [[ $1 =~ (dev)-.+ || $1 =~ .+(@dev|.x-dev) || $1 =~ (alpha|beta|RC|rc)[0-9]+ ]]; then
-    VERSION=$1
+    EXACT_VERSION_OR_MINOR="$1"
     STABILITY_FLAG=${BASH_REMATCH[1]}
   else
     if [[ $1 =~ ([0-9]+\.[0-9]+)\.[0-9] ]]; then
-      VERSION=~${BASH_REMATCH[1]}.0
+      EXACT_VERSION_OR_MINOR="~${BASH_REMATCH[1]}.0"
     else
       echo >&2 "Version $1 could not be parsed."
       exit 1
@@ -55,8 +55,8 @@ fi
 
 echo "Setting distribution dependencies"
 
-# Require exact versions of the main packages
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/flow:${VERSION}"
+# Require exact versions or minor level of the main packages
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/flow:${EXACT_VERSION_OR_MINOR}"
 
 # Require some version of the same minor level of the main packages
 if [[ ${STABILITY_FLAG} ]]; then
@@ -80,7 +80,7 @@ else
 fi
 
 # Require exact versions of the main dev packages
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/kickstarter:${VERSION}"
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/kickstarter:${EXACT_VERSION_OR_MINOR}"
 
 # Require some version of the same minor level of main dev packages
 if [[ ${STABILITY_FLAG} ]]; then
@@ -90,7 +90,7 @@ else
   php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:~${BRANCH}.0"
   php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:~${BRANCH}.0"
 fi
-commit_manifest_update "${BRANCH}" "${BUILD_URL}" "${VERSION}" "Distribution"
+commit_manifest_update "${BRANCH}" "${BUILD_URL}" "${EXACT_VERSION_OR_MINOR}" "Distribution"
 
 echo "Setting packages dependencies"
 
@@ -98,5 +98,5 @@ php "${COMPOSER_PHAR}" --working-dir=Packages/Application/Neos.Welcome require -
 php "${COMPOSER_PHAR}" --working-dir=Packages/Application/Neos.Welcome require --no-update "neos/fluid-adaptor:~${BRANCH}.0"
 php "${COMPOSER_PHAR}" --working-dir=Packages/Application/Neos.Behat require --no-update "neos/flow:~${BRANCH}.0"
 
-commit_manifest_update ${BRANCH} "${BUILD_URL}" ${VERSION} "Packages/Application/Neos.Behat"
-commit_manifest_update ${BRANCH} "${BUILD_URL}" ${VERSION} "Packages/Application/Neos.Welcome"
+commit_manifest_update ${BRANCH} "${BUILD_URL}" ${EXACT_VERSION_OR_MINOR} "Packages/Application/Neos.Behat"
+commit_manifest_update ${BRANCH} "${BUILD_URL}" ${EXACT_VERSION_OR_MINOR} "Packages/Application/Neos.Welcome"

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -84,8 +84,13 @@ php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neo
 
 # Require some version of the same minor level of main dev packages
 if [[ ${STABILITY_FLAG} ]]; then
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:${BRANCH}.x-dev"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${BRANCH}.x-dev"
+  # using alias as "stable" so testing helper packages can declare a dependency
+  STABILITY_ALIAS=" as ${BRANCH}"
+  if [[ "${COMPOSER_STABILITY_FLAG}" == "dev" ]]; then
+    STABILITY_ALIAS=""
+  fi
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:${BRANCH}.x-dev${STABILITY_ALIAS}"
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${BRANCH}.x-dev${STABILITY_ALIAS}"
 else
   php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:~${BRANCH}.0"
   php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:~${BRANCH}.0"

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -65,39 +65,18 @@ else
   php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/welcome:~${BRANCH}.0"
 fi
 
-# Require exact versions of sub dependency packages, allowing unstable
+# Allow main packages require their required sub dependency packages, allowing unstable
 if [[ ${STABILITY_FLAG} ]]; then
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/cache:${VERSION}"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/eel:${VERSION}"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/error-messages:${VERSION}"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/flow-log:${VERSION}"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/utility-arrays:${VERSION}"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/utility-files:${VERSION}"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/utility-mediatypes:${VERSION}"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/utility-objecthandling:${VERSION}"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/utility-opcodecache:${VERSION}"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/utility-pdo:${VERSION}"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/utility-schema:${VERSION}"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/utility-unicode:${VERSION}"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/http-factories:${VERSION}"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/fluid-adaptor:${VERSION}"
-# Remove dependencies not needed if releasing a stable version
+  if [[ "$STABILITY_FLAG" =~ ^(dev|alpha|beta|RC|rc)$ ]]; then
+    COMPOSER_STABILITY_FLAG=${STABILITY_FLAG}
+  else
+    COMPOSER_STABILITY_FLAG="dev"
+  fi
+  composer config minimum-stability $COMPOSER_STABILITY_FLAG
+  composer config prefer-stable true
 else
-  # Remove requirements for development version of sub dependency packages
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/cache"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/eel"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/error-messages"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/flow-log"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-arrays"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-files"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-mediatypes"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-objecthandling"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-opcodecache"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-pdo"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-schema"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-unicode"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/http-factories"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/fluid-adaptor"
+  composer config --unset prefer-stable
+  composer config --unset minimum-stability
 fi
 
 # Require exact versions of the main dev packages

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -72,11 +72,11 @@ if [[ ${STABILITY_FLAG} ]]; then
   else
     COMPOSER_STABILITY_FLAG="dev"
   fi
-  composer config minimum-stability $COMPOSER_STABILITY_FLAG
-  composer config prefer-stable true
+  php "${COMPOSER_PHAR}" --working-dir=Distribution config minimum-stability $COMPOSER_STABILITY_FLAG
+  php "${COMPOSER_PHAR}" --working-dir=Distribution config prefer-stable true
 else
-  composer config --unset prefer-stable
-  composer config --unset minimum-stability
+  php "${COMPOSER_PHAR}" --working-dir=Distribution config --unset prefer-stable
+  php "${COMPOSER_PHAR}" --working-dir=Distribution config --unset minimum-stability
 fi
 
 # Require exact versions of the main dev packages

--- a/composer.json
+++ b/composer.json
@@ -21,24 +21,12 @@
             "neos/composer-plugin": true
         }
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "neos/flow-development-collection": "9.2.x-dev",
         "neos/welcome": "9.2.x-dev",
-        "neos/flow": "9.2.x-dev",
-        "neos/cache": "9.2.x-dev",
-        "neos/eel": "9.2.x-dev",
-        "neos/error-messages": "9.2.x-dev",
-        "neos/flow-log": "9.2.x-dev",
-        "neos/utility-arrays": "9.2.x-dev",
-        "neos/utility-files": "9.2.x-dev",
-        "neos/utility-mediatypes": "9.2.x-dev",
-        "neos/utility-objecthandling": "9.2.x-dev",
-        "neos/utility-opcodecache": "9.2.x-dev",
-        "neos/utility-pdo": "9.2.x-dev",
-        "neos/utility-schema": "9.2.x-dev",
-        "neos/utility-unicode": "9.2.x-dev",
-        "neos/http-factories": "9.2.x-dev",
-        "neos/fluid-adaptor": "9.2.x-dev"
+        "neos/flow": "9.2.x-dev"
     },
     "repositories": {
         "distributionPackages": {

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,6 @@
     "require": {
         "neos/flow-development-collection": "9.2.x-dev",
         "neos/welcome": "9.2.x-dev",
-        "phpunit/phpunit": "^9.6.20",
-        "mikey179/vfsstream": "^1.6.10",
-        "phpstan/phpstan": "^1.10.0",
         "neos/flow": "9.2.x-dev",
         "neos/cache": "9.2.x-dev",
         "neos/eel": "9.2.x-dev",
@@ -63,6 +60,9 @@
     "require-dev": {
         "neos/kickstarter": "9.2.x-dev",
         "neos/buildessentials": "9.2.x-dev",
-        "neos/behat": "9.2.x-dev"
+        "neos/behat": "9.2.x-dev",
+        "phpunit/phpunit": "^9.6.20",
+        "mikey179/vfsstream": "^1.6.10",
+        "phpstan/phpstan": "^1.10.0"
     }
 }


### PR DESCRIPTION
Neos PR https://github.com/neos/neos-development-distribution/pull/116

This is way easier to maintain than including the duplicated list of packages in this release script.

We did this also for the Neos 9.0 betas (see https://github.com/neos/neos-base-distribution/commit/39f7d21bc2c26d6e461a566468aee1cbd4a0cdc1) as in Neos the count of dependencies manually to require got mad, but adding the minimum stability manually required us to remove that manually also which we did not do in time for the actual release again:D


TODO:
- [ ] manually remove explicit sub dependencies from dev distribution: https://github.com/neos/flow-development-distribution/blob/77e485dfc4cde9bb6e151945fd49524d04080e58/composer.json#L31-L44
  - > we also use minimum-stability there now 
