### PR TITLE
TASK: Add rector and php codesniffer to the dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,8 @@
         "phpunit/phpunit": "^9.6.20",
         "mikey179/vfsstream": "^1.6.10",
         "phpstan/phpstan": "^1.10.0",
+        "squizlabs/php_codesniffer": "^3.6",
+        "rector/rector": "^1.2",
         "neos/flow": "9.2.x-dev",
         "neos/cache": "9.2.x-dev",
         "neos/eel": "9.2.x-dev",


### PR DESCRIPTION
This will allow to use this tooling in github actions later ...

- the rector version is the most recent version of rector that is compatible with our version of phpstan.
- the phpcs version is the same that is used in the neos-dev-dist

The equivalent pr for the neos-dev-dist is: https://github.com/neos/neos-development-distribution/pull/119